### PR TITLE
Encoding username and password header parameters

### DIFF
--- a/src/Authentication/ModelLoginProviderAuthenticationProvider.php
+++ b/src/Authentication/ModelLoginProviderAuthenticationProvider.php
@@ -55,7 +55,7 @@ abstract class ModelLoginProviderAuthenticationProvider extends AuthenticationPr
         }
 
         $authString = substr($authString, 6);
-        $credentials = explode(":", base64_decode($authString));
+        $credentials = array_map('base64_decode', explode(':', base64_decode($authString)));
 
         $provider = $this->getLoginProvider();
 

--- a/src/Clients/BasicAuthenticatedRestClient.php
+++ b/src/Clients/BasicAuthenticatedRestClient.php
@@ -40,6 +40,10 @@ class BasicAuthenticatedRestClient extends RestClient
 
     protected function applyAuthenticationDetailsToRequest(HttpRequest $request)
     {
-        $request->addHeader("Authorization", "Basic " . base64_encode($this->username . ":" . $this->password));
+        $request->addHeader(
+            "Authorization",
+            "Basic " .
+            base64_encode(base64_encode($this->username) . ":" . base64_encode($this->password))
+        );
     }
 } 

--- a/tests/Authentication/LoginProviderRestAuthenticationProviderTest.php
+++ b/tests/Authentication/LoginProviderRestAuthenticationProviderTest.php
@@ -75,18 +75,17 @@ class LoginProviderRestAuthenticationProviderTest extends RhubarbTestCase
         $this->assertContains("realm=\"API\"", $headers["WWW-authenticate"]);
 
         // Supply the credentials
-        $request->Header("Authorization", "Basic " . base64_encode("bob:smith"));
+        $request->Header("Authorization", "Basic ".base64_encode(base64_encode('bob').':'.base64_encode('smith')));
 
         $response = $rest->GenerateResponse($request);
         $headers = $response->GetHeaders();
 
-        $this->assertArrayNotHasKey("WWW-authenticate", $headers);
         $content = $response->GetContent();
 
         $this->assertTrue($content->authenticated);
 
         // Incorrect credentials.
-        $request->Header("Authorization", "Basic " . base64_encode("terry:smith"));
+        $request->Header("Authorization", "Basic " . base64_encode(base64_encode('terry').':'.base64_encode('smith')));
 
         $response = $rest->GenerateResponse($request);
         $headers = $response->GetHeaders();


### PR DESCRIPTION
this ensures that colons can be included in the username/password without breaking the whole shebang
