### PR TITLE
HTTP error codes for all failure responses

### DIFF
--- a/src/UrlHandlers/BinaryRestResourceHandler.php
+++ b/src/UrlHandlers/BinaryRestResourceHandler.php
@@ -51,6 +51,7 @@ class BinaryRestResourceHandler extends RestResourceHandler
             $response->setContent($this->buildErrorResponse("The resource could not be found."));
         } catch (RestImplementationException $er) {
             $response = new JsonResponse($this);
+            $response->setResponseCode(500);
             $response->setContent($this->buildErrorResponse($er->getPublicMessage()));
         }
 

--- a/src/UrlHandlers/RestResourceHandler.php
+++ b/src/UrlHandlers/RestResourceHandler.php
@@ -178,6 +178,7 @@ class RestResourceHandler extends RestHandler
                 $response->setContent($this->buildErrorResponse("An unknown error occurred during the operation."));
             }
         } catch (RestImplementationException $er) {
+            $response->setResponseCode(500);
             $response->setContent($this->buildErrorResponse($er->getMessage()));
         }
 
@@ -260,10 +261,8 @@ class RestResourceHandler extends RestHandler
         return $response;
     }
 
-    protected function buildErrorResponse($message = "", $httpResponseCode = 500)
+    protected function buildErrorResponse($message = "")
     {
-        http_response_code($httpResponseCode);
-
         $date = new RhubarbDateTime("now");
 
         $response = new \stdClass();


### PR DESCRIPTION
Setting error codes in all Rest failure cases, to avoid having a 200 response for a failure.

Also allowing PUT to respond with content instead of only a success boolean. If a PUT resource includes updating related or inserted models, we may want to pass these back down so that new auto-IDs or any other server-generated updates are retrieved.
