### PR TITLE
RestApiHandler not returning a Rhubarb response object

### DIFF
--- a/src/Adapters/ModelResourceAdapter.php
+++ b/src/Adapters/ModelResourceAdapter.php
@@ -110,6 +110,11 @@ class ModelResourceAdapter extends ResourceAdapter
     public function putResource($resource)
     {
         $modelClass = $this->modelClassName;
+
+        if (!isset($resource["id"])) {
+            throw new ResourceNotFoundException();
+        }
+
         /**
          * @var $model Model
          */
@@ -120,6 +125,15 @@ class ModelResourceAdapter extends ResourceAdapter
         $model->save();
 
         return $model;
+    }
+
+    protected function applyParamsToPayload($payload, $params)
+    {
+        if (isset($params["id"])) {
+            $payload["id"] = $params["id"];
+        }
+
+        return parent::applyParamsToPayload($payload, $params);
     }
 
     protected function filterCollection(Collection $collection, $params, ?WebRequest $request = null)

--- a/src/Adapters/ModelResourceAdapter.php
+++ b/src/Adapters/ModelResourceAdapter.php
@@ -164,4 +164,8 @@ class ModelResourceAdapter extends ResourceAdapter
 
         return $this->makeResourceFromData($model);
     }
+
+    public function delete($payload, $params, ?WebRequest $request)
+    {
+    }
 }

--- a/src/Adapters/ResourceAdapter.php
+++ b/src/Adapters/ResourceAdapter.php
@@ -4,6 +4,7 @@ namespace Rhubarb\RestApi\Adapters;
 
 use Rhubarb\Crown\Request\WebRequest;
 use Rhubarb\RestApi\Exceptions\ResourceNotFoundException;
+use Rhubarb\RestApi\Exceptions\RequestPayloadValidationException;
 use Rhubarb\RestApi\Resources\ListResource;
 
 /**
@@ -20,11 +21,22 @@ abstract class ResourceAdapter
      */
     public function put($payload, $params, ?WebRequest $request)
     {
+        $payload = $this->validatePutRequestPayload($payload);
+
+        $payload = $this->applyParamsToPayload($payload, $params);
+
         $resource = $this->get($params, $request);
 
         $this->putResource($payload);
 
         return $this->get($params, $request);
+    }
+
+    protected function validatePutRequestPayload($payload)
+    {
+        $this->validateRequestPayload($payload);
+
+        return $payload;
     }
 
     public function get($params, ?WebRequest $request)
@@ -59,9 +71,26 @@ abstract class ResourceAdapter
 
     public abstract function post($payload, $params, WebRequest $request);
 
+    protected function validatePostRequestPayload($payload)
+    {
+        $this->validateRequestPayload($payload);
+    }
+
     public abstract function delete($payload, $params, ?WebRequest $request);
 
     protected abstract function countItems($rangeStart, $rangeEnd, $params, ?WebRequest $request);
 
     protected abstract function getItems($rangeStart, $rangeEnd, $params, ?WebRequest $request);
+
+    protected function applyParamsToPayload($payload, $params)
+    {
+        return $payload;
+    }
+
+    private final function validateRequestPayload($payload)
+    {
+        if (!is_array($payload)) {
+            throw new RequestPayloadValidationException("POST and PUT options require a JSON encoded resource object in the body of the request.");
+        }
+    }
 }

--- a/src/Adapters/ResourceAdapter.php
+++ b/src/Adapters/ResourceAdapter.php
@@ -59,6 +59,8 @@ abstract class ResourceAdapter
 
     public abstract function post($payload, $params, WebRequest $request);
 
+    public abstract function delete($payload, $params, ?WebRequest $request);
+
     protected abstract function countItems($rangeStart, $rangeEnd, $params, ?WebRequest $request);
 
     protected abstract function getItems($rangeStart, $rangeEnd, $params, ?WebRequest $request);

--- a/src/Adapters/ResourceAdapter.php
+++ b/src/Adapters/ResourceAdapter.php
@@ -22,10 +22,6 @@ abstract class ResourceAdapter
     {
         $resource = $this->get($params, $request);
 
-        if ($resource->id != $payload["id"]){
-            throw new ResourceNotFoundException();
-        }
-
         $this->putResource($payload);
 
         return $this->get($params, $request);

--- a/src/Exceptions/RequestPayloadValidationException.php
+++ b/src/Exceptions/RequestPayloadValidationException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Rhubarb\RestApi\Exceptions;
+
+use Rhubarb\Crown\Exceptions\RhubarbException;
+
+class RequestPayloadValidationException extends RhubarbException
+{
+
+}

--- a/src/UrlHandlers/RestApiHandler.php
+++ b/src/UrlHandlers/RestApiHandler.php
@@ -3,8 +3,10 @@
 namespace Rhubarb\RestApi\UrlHandlers;
 
 use Rhubarb\Crown\Response\HtmlResponse;
+use Rhubarb\Crown\Response\NotAuthorisedResponse;
 use Rhubarb\RestApi\Endpoints\CallableEndpoint;
 use Rhubarb\RestApi\Endpoints\Endpoint;
+use Rhubarb\RestApi\Exceptions\RequestPayloadValidationException;
 use Rhubarb\RestApi\Exceptions\ResourceNotFoundException;
 use Rhubarb\Crown\Request\WebRequest;
 use Rhubarb\Crown\Response\JsonResponse;
@@ -160,6 +162,9 @@ class RestApiHandler extends UrlHandler
                 } catch (ResourceNotFoundException $er){
                     $response = new NotFoundResponse();
                     $response->setContent("The resource could not be located.");
+                } catch (RequestPayloadValidationException $er){
+                    $response = new NotAuthorisedResponse();
+                    $response->setContent($er->getMessage());
                 } catch (\Throwable $er){
                     $response = new Response();
                     $response->setResponseCode(500);

--- a/src/UrlHandlers/RestApiHandler.php
+++ b/src/UrlHandlers/RestApiHandler.php
@@ -150,8 +150,13 @@ class RestApiHandler extends UrlHandler
                     }
 
                     $payload = $endpoint->processRequest($matches, $request);
-                    $response = new JsonResponse();
-                    $response->setContent($payload);
+
+                    if ($payload instanceof Response) {
+                        $response = $payload;
+                    } else {
+                        $response = new JsonResponse();
+                        $response->setContent($payload);
+                    }
                 } catch (ResourceNotFoundException $er){
                     $response = new NotFoundResponse();
                     $response->setContent("The resource could not be located.");


### PR DESCRIPTION
This fixes an issue where the middleware layer was returning a valid response object but we were ignoring it and always returning a JsonResponse object. The example of the issue this fixes is on login the TokenAuthenticationMiddleware that validates your login was returning a **TokenAuthorisationRequiredResponse** object which we never returned.

The content of this response was not being adhered to and we were defaulting it to a standard JsonResponse object.