### PR TITLE
Only lowercase the first character on the ModelResourceAdapter mapping

### DIFF
--- a/src/Adapters/ModelResourceAdapter.php
+++ b/src/Adapters/ModelResourceAdapter.php
@@ -71,8 +71,8 @@ class ModelResourceAdapter extends ResourceAdapter
         $resource->id = $model->getUniqueIdentifier();
 
         foreach($model->exportData() as $prop => $value) {
-            if (isset($lcaseProps[strtolower($prop)])){
-                $propName = $lcaseProps[strtolower($prop)];
+            if (isset($lcaseProps[lcfirst($prop)])){
+                $propName = $lcaseProps[lcfirst($prop)];
                 $resource->$propName = $value;
             }
         }

--- a/src/Adapters/ModelResourceAdapter.php
+++ b/src/Adapters/ModelResourceAdapter.php
@@ -56,7 +56,7 @@ class ModelResourceAdapter extends ResourceAdapter
         $lcaseProps = [];
 
         foreach($props as $prop) {
-            $lcaseProps[strtolower($prop->name)] = $prop->name;
+            $lcaseProps[lcfirst($prop->name)] = $prop->name;
         }
 
         return $lcaseProps;


### PR DESCRIPTION
Adding support to only lowercase the first character on the ModelResourceAdapter. This will then support mapping to properties such as:

**Model**     **UserResource**
RoleId        =>  roleId